### PR TITLE
Update labs.ipynb

### DIFF
--- a/labs.ipynb
+++ b/labs.ipynb
@@ -8,7 +8,7 @@
     "This notebook contains the PySpark scripts run in AWS Glue to transform the data in the data lake. Each section refers a section in the lab. \n",
     "\n",
     "## Initialization\n",
-    "The first section initializes the Spark environment and only needs to be run once."
+    "The first two sections initialize the Spark environment and only need to be run once. The first block may take a few seconds as it negotiates the Spark session."
    ]
   },
   {
@@ -25,8 +25,15 @@
     "from awsglue.context import GlueContext\n",
     "from awsglue.job import Job\n",
     "from pyspark.sql.functions import *\n",
-    "from awsglue.dynamicframe import DynamicFrame\n",
-    "\n",
+    "from awsglue.dynamicframe import DynamicFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "## @ set up a single GlueContext.\n",
     "sc = SparkContext.getOrCreate()\n",
     "\n",


### PR DESCRIPTION
Separated the imports from the creation of the glue context.  Without this the context can fail to create as the session with the Spark server takes a few seconds.

*Issue #, if available:*

*Description of changes:*
Separated the imports from the glue context creation code. Because the imports initiate the spark session, there is a small delay for the connection to be established. As a result the glue context creation was happening before the connection was negotiated, and it was failing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
